### PR TITLE
Simplify/avoid stutter in function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - Supports globstar/doublestar (`**`).
 - Provides a fast `Glob` function.
-- Provides a `NewMultiMatcher` for combining multiple patterns to be matched.
+- Supports combining matchers.
 
 ## Examples
 
@@ -35,7 +35,7 @@ package main
 import "github.com/saracen/matcher"
 
 func main() {
-    matches, err := matcher.Glob(context.Background(), ".", matcher.NewMatcher("**/*.go"))
+    matches, err := matcher.Glob(context.Background(), ".", matcher.New("**/*.go"))
     if err != nil {
         panic(err)
     }
@@ -53,9 +53,9 @@ package main
 import "github.com/saracen/matcher"
 
 func main() {
-    matcher := matcher.NewMultiMatcher(
-        matcher.NewMatcher("**/*.go"),
-        matcher.NewMatcher("**/*.txt"))
+    matcher := matcher.Multi(
+        matcher.New("**/*.go"),
+        matcher.New("**/*.txt"))
 
     matches, err := matcher.Glob(context.Background(), ".", matcher)
     if err != nil {

--- a/matcher.go
+++ b/matcher.go
@@ -34,7 +34,7 @@ type matcher struct {
 	options matchOptions
 }
 
-// NewMatcher returns a new Matcher.
+// New returns a new Matcher.
 //
 // The Matcher returned uses the same rules as Match, but returns a result of
 // either NotMatched, Matched or Follow.
@@ -42,7 +42,7 @@ type matcher struct {
 // Follow hints to the caller that whilst the pattern wasn't matched, path
 // traversal might yield matches. This allows for more efficient globbing,
 // preventing path traversal where a match is impossible.
-func NewMatcher(pattern string, opts ...MatchOption) Matcher {
+func New(pattern string, opts ...MatchOption) Matcher {
 	matcher := matcher{pattern: strings.Split(pattern, separator)}
 	for _, o := range opts {
 		o(&matcher.options)
@@ -62,7 +62,7 @@ func NewMatcher(pattern string, opts ...MatchOption) Matcher {
 // The only possible returned error is ErrBadPattern, when the pattern
 // is malformed.
 func Match(pattern, pathname string, opts ...MatchOption) (bool, error) {
-	result, err := NewMatcher(pattern, opts...).Match(pathname)
+	result, err := New(pattern, opts...).Match(pathname)
 
 	return result == Matched, err
 }

--- a/matcher_multi.go
+++ b/matcher_multi.go
@@ -2,12 +2,13 @@ package matcher
 
 type multiMatcher []Matcher
 
-// NewMultiMatcher returns a new Matcher that matches against many matchers.
-func NewMultiMatcher(matches ...Matcher) Matcher {
+// Multi returns a new Matcher that matches against many matchers.
+func Multi(matches ...Matcher) Matcher {
 	return multiMatcher(matches)
 }
 
-// Match uses both the include and exclude patterns to determine matches.
+// Match performs a match with all matchers provided and returns a result
+// early if one matched.
 func (p multiMatcher) Match(pathname string) (Result, error) {
 	var follow bool
 

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -291,9 +291,9 @@ func TestNewMatcher(t *testing.T) {
 		tests := tests
 		t.Run(tn, func(t *testing.T) {
 			for _, tt := range tests {
-				result, err := NewMatcher(tt.pattern).Match(tt.s)
+				result, err := New(tt.pattern).Match(tt.s)
 				if result != tt.result || err != tt.err {
-					t.Errorf("NewMatcher(%#q).Match(%#q) = (%v, %v) want (%v, %v)", tt.pattern, tt.s, result, err, tt.result, tt.err)
+					t.Errorf("New(%#q).Match(%#q) = (%v, %v) want (%v, %v)", tt.pattern, tt.s, result, err, tt.result, tt.err)
 					return
 				}
 			}
@@ -319,13 +319,13 @@ func TestMultiMatcher(t *testing.T) {
 		"yyy/aaa/yyy":                         NotMatched,
 	}
 
-	includes := NewMultiMatcher(
-		NewMatcher("aaa/**/ccc/**/eee"),
-		NewMatcher("zzz/**"),
+	includes := Multi(
+		New("aaa/**/ccc/**/eee"),
+		New("zzz/**"),
 	)
-	excludes := NewMultiMatcher(
-		NewMatcher("aaa/bbb/ccc/ddd/eee"),
-		NewMatcher("zzz/**"),
+	excludes := Multi(
+		New("aaa/bbb/ccc/ddd/eee"),
+		New("zzz/**"),
 	)
 
 	for path, tt := range tests {
@@ -369,7 +369,7 @@ func TestMatchFunc(t *testing.T) {
 	}
 
 	for path, tt := range tests {
-		result, err := NewMatcher("a*/**/ccc/**/eee", WithMatchFunc(match)).Match(path)
+		result, err := New("a*/**/ccc/**/eee", WithMatchFunc(match)).Match(path)
 		if err != nil {
 			t.Error(err)
 		}
@@ -381,9 +381,9 @@ func TestMatchFunc(t *testing.T) {
 }
 
 func TestMultiMatcherInvalid(t *testing.T) {
-	_, err := NewMultiMatcher(
-		NewMatcher("abc"),
-		NewMatcher("[]a]"),
+	_, err := Multi(
+		New("abc"),
+		New("[]a]"),
 	).Match("abcdef")
 
 	if err == nil {
@@ -410,7 +410,7 @@ func TestGlob(t *testing.T) {
 	ioutil.WriteFile(filepath.Join(dir, "files", "dir3", "file4.txt"), []byte{}, 0600)
 	ioutil.WriteFile(filepath.Join(dir, "ignore", "dir4", "file5.txt"), []byte{}, 0600)
 
-	matches, err := Glob(context.Background(), dir, NewMatcher("files/**/*.txt"))
+	matches, err := Glob(context.Background(), dir, New("files/**/*.txt"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -435,9 +435,9 @@ func TestGlobMultiMatcher(t *testing.T) {
 	ioutil.WriteFile(filepath.Join(dir, "files", "dir1", "File2.txt"), []byte{}, 0600)
 	ioutil.WriteFile(filepath.Join(dir, "files", "dir2", "File3.txt"), []byte{}, 0600)
 
-	matches, err := Glob(context.Background(), dir, NewMultiMatcher(
-		NewMatcher(strings.ToLower("files/DIR1/file1.txt")),
-		NewMatcher(strings.ToLower("files/DIR1/file2.txt")),
+	matches, err := Glob(context.Background(), dir, Multi(
+		New(strings.ToLower("files/DIR1/file1.txt")),
+		New(strings.ToLower("files/DIR1/file2.txt")),
 	), WithPathTransformer(strings.ToLower))
 	if err != nil {
 		t.Error(err)
@@ -454,7 +454,7 @@ var globPattern = flag.String("globpattern", "pkg/**/*.go", "The pattern to use 
 func BenchmarkGlob(b *testing.B) {
 	b.ReportAllocs()
 
-	m := NewMatcher(*globPattern)
+	m := New(*globPattern)
 	for n := 0; n < b.N; n++ {
 		_, err := Glob(context.Background(), *globDir, m)
 		if err != nil {
@@ -467,7 +467,7 @@ func BenchmarkGlob(b *testing.B) {
 func BenchmarkGlobWithDoublestarMatch(b *testing.B) {
 	b.ReportAllocs()
 
-	m := NewMatcher(*globPattern, WithMatchFunc(doublestar.Match))
+	m := New(*globPattern, WithMatchFunc(doublestar.Match))
 	for n := 0; n < b.N; n++ {
 		_, err := Glob(context.Background(), *globDir, m)
 		if err != nil {


### PR DESCRIPTION
Originally, there was going to be different types of matchers built in, therefore `NewThingMatcher` made sense.

However, now that the underlying matcher function can be changed (`WithMatchFunc`) this is less of a concern.

`matcher.NewMatcher` becomes `matcher.New`

`matcher.NewMultiMatcher` becomes `matcher.Multi`